### PR TITLE
Change fieldFromJs to allow setting fields as null/undefined

### DIFF
--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -1382,6 +1382,9 @@ struct FromJsConverter {
 
   bool fieldFromJs(capnp::DynamicStruct::Builder builder, capnp::StructSchema::Field field,
                    v8::Handle<v8::Value> js) {
+    if (js->IsNull() || js->IsUndefined()) {
+      return true;
+    }
     auto proto = field.getProto();
     switch (proto.which()) {
       case capnp::schema::Field::SLOT: {


### PR DESCRIPTION
Before this, string fields would accept null/undefined, and immediately
call toString() on them, resulting in "null"/"undefined". Other field
types would error out. Now we allow setting fields as null/undefined, so
doing something like:
```js
myCap.myMethod(1, "2", null, "4", myObj["notAKey"])
```
is possible.