### PR TITLE
Rename error.type to kjType

### DIFF
--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -663,7 +663,7 @@ v8::Local<v8::Value> toJsException(kj::Exception&& exception) {
       case kj::Exception::Type::DISCONNECTED  : type = "disconnected" ; break;
       case kj::Exception::Type::UNIMPLEMENTED : type = "unimplemented"; break;
     }
-    obj->Set(v8::String::NewSymbol("type"), v8::String::NewSymbol(type));
+    obj->Set(v8::String::NewSymbol("kjType"), v8::String::NewSymbol(type));
   } else {
     KJ_LOG(WARNING, "v8 exception is not an object?");
   }

--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -677,7 +677,7 @@ kj::Exception fromJsException(v8::Handle<v8::Value> exception) {
   if (exception->IsObject()) {
     v8::HandleScope scope;
     v8::Object* obj = v8::Object::Cast(*exception);
-    v8::Handle<v8::Value> value = obj->Get(v8::String::NewSymbol("type"));
+    v8::Handle<v8::Value> value = obj->Get(v8::String::NewSymbol("kjType"));
     if (!value.IsEmpty() && !value->IsUndefined()) {
       auto name = toKjString(value);
       if (name == "overloaded") {


### PR DESCRIPTION
This a workaround due to a v8 bug:
https://code.google.com/p/v8/issues/detail?id=2397