### PR TITLE
simplify RPC calling convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ we copied.)
     var cap = conn.restore("exportName", foo.MyInterface);
 
 ### Making an RPC call
-    
-    // Method parameters are native Javascript values, converted using the
-    // same rules as capnp.serialize().
-    var promise = cap.someMethod("foo", 123, {a: 1, b: 2});
+
+    // Method parameters are passed as a single native Javascript object,
+    // converted using the same rules as capnp.serialize().
+    var promise = cap.someMethod({a: "some text", b: 123});
 
     // Methods return ES6 "Promise" objects.  The response is a Javascript
     // object containing the results by name.
@@ -156,7 +156,7 @@ You could write:
     }
 
     // Use it in a call.
-    someBar.bar(myFoo);
+    someBar.bar({foo: myFoo});
 
 Cap'n Proto protocols often depend on explicit notification when there are
 no more references to an object. In C++ this would be accomplished by
@@ -176,8 +176,8 @@ as soon as there are no more references.
 Note, however, that `close()` will be called once for every time your
 native object is coerced to a capability. So, if you did:
 
-    someBar.bar(myFoo);
-    someBar.bar(myFoo);
+    someBar.bar({foo: myFoo});
+    someBar.bar({foo: myFoo});
 
 Then `myFoo.close()` will eventually be called twice. To prevent this,
 you can explicitly convert your object to a capability once upfront, and
@@ -185,8 +185,8 @@ then use that:
 
     var cap = new capnp.Capability(myFoo, mySchema.Foo);
 
-    someBar.bar(cap);
-    someBar.bar(cap);
+    someBar.bar({foo: cap});
+    someBar.bar({foo: cap});
 
     // Close our own copy of the reference. Note that this does not
     // necessarily call `myFoo.close()` -- that happens only after the

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ You could write:
 
     // Implement the Foo interface.
     var myFoo = {
-      foo: function (a, b) {
-        return {c: "blah"};
+      foo: function (params) {
+        return {c: "Got params: ( " + params.a + ", " + params.b + ")"};
       }
     }
 
@@ -165,8 +165,8 @@ Instead, you may give your object a `close()` method, which will be called
 as soon as there are no more references.
 
     var myFoo = {
-      foo: function (a, b) {
-        return {c: "blah"};
+      foo: function (params) {
+        return {c: "Got params: ( " + params.a + ", " + params.b + ")"};
       },
       close: () {
         console.log("client disconnected");

--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -1368,8 +1368,6 @@ v8::Handle<v8::Value> fromJs(const v8::Arguments& args) {
   //
   // Copies the contents of a JS object into a struct builder.
   //
-  // If `jso` is an array, it will be treated as an argument list ordered by ordinal.
-  //
   // `LocalCap` is a constructor that takes a JS object as a parameter and produces a new object
   // that would be appropriate to pass to `newCap`.  Normally this means wrapping each method to
   // take an RPC request as its input.
@@ -1388,21 +1386,11 @@ v8::Handle<v8::Value> fromJs(const v8::Arguments& args) {
 
     FromJsConverter converter = { context, args.Data(), localCapType };
 
-    if (jsValue->IsArray()) {
-      v8::Array* array = v8::Array::Cast(*jsValue);
-      auto fields = schema.getFields();
-      uint length = kj::min(array->Length(), fields.size());
-
-      for (uint i = 0; i < length; i++) {
-        if (!converter.fieldFromJs(builder, fields[i], array->Get(i))) {
-          break;
-        }
-      }
-    } else if (jsValue->IsObject()) {
+    if (jsValue->IsObject()) {
       converter.structFromJs(builder, v8::Object::Cast(*jsValue));
     } else {
       v8::ThrowException(v8::Exception::TypeError(v8::String::New(
-          "fromJs() requires an array or an object.")));
+          "fromJs() requires an object.")));
     }
 
     return v8::Undefined();

--- a/src/node-capnp/capnp.cc
+++ b/src/node-capnp/capnp.cc
@@ -1577,36 +1577,6 @@ v8::Handle<v8::Value> toJs(const v8::Arguments& args) {
   });
 }
 
-v8::Handle<v8::Value> toJsParams(const v8::Arguments& args) {
-  // toJsParams(reader, CapType) -> array
-  //
-  // Like toJs(), but interprets the input as a method parameter struct and produces a parameter
-  // array from it.
-
-  KJV8_UNWRAP(CapnpContext, context, args.Data());
-  KJV8_UNWRAP_READER(reader, args[0]);
-
-  return liftKj([&]() -> v8::Handle<v8::Value> {
-    auto schema = reader.getSchema();
-    if (schema.getProto().getScopeId() == 0) {
-      // This appears to be a parameter set.
-      // (TODO(cleanup):  Detecting this by scope ID seems ugly, but currently there's no other
-      // way.)
-
-      auto fields = schema.getFields();
-      auto result = v8::Array::New(fields.size());
-      for (uint i: kj::indices(fields)) {
-        result->Set(i, valueToJs(context, reader.get(fields[i]), fields[i].getType(), args[1]));
-      }
-      return result;
-    } else {
-      auto result = v8::Array::New(1);
-      result->Set(0, valueToJs(context, reader, reader.getSchema(), args[1]));
-      return result;
-    }
-  });
-}
-
 // -----------------------------------------------------------------------------
 
 v8::Handle<v8::Value> fromBytes(const v8::Arguments& args) {
@@ -2297,7 +2267,6 @@ void init(v8::Handle<v8::Object> exports) {
     mapFunction("structToString", structToString);
     mapFunction("fromJs", fromJs);
     mapFunction("toJs", toJs);
-    mapFunction("toJsParams", toJsParams);
     mapFunction("fromBytes", fromBytes);
     mapFunction("toBytes", toBytes);
     mapFunction("connect", connect);

--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -148,9 +148,9 @@ function settleCaps(pipeline, final) {
 }
 
 function makeMethod(cap, method) {
-  return function () {
+  return function (params) {
     var req = v8capnp.request(cap, method);
-    v8capnp.fromJs(req, Array.prototype.slice.call(arguments, 0), LocalCapWrapper);
+    v8capnp.fromJs(req, params ? params : {}, LocalCapWrapper);
     var pipeline;
     var promise = new Promise(function (resolve, reject) {
       pipeline = v8capnp.send(req, resolve, reject, Capability);

--- a/src/node-capnp/capnp.js
+++ b/src/node-capnp/capnp.js
@@ -167,9 +167,9 @@ function makeMethod(cap, method) {
 
 function wrapLocalMethod(self, method) {
   return function (request) {
-    var params = v8capnp.toJsParams(request, Capability);
+    var params = v8capnp.toJs(request, Capability);
     v8capnp.releaseParams(request);
-    Promise.resolve(method.apply(self, params)).then(function (results) {
+    Promise.resolve(method.apply(self, [params])).then(function (results) {
       if (typeof results !== "object") {
         if (results === undefined) {
           results = [];


### PR DESCRIPTION
## How things are today
In its current state, node-capnp (usually) unpacks RPC method arguments into javascript function arguments. For example, if we have an interface:

```capnp
interface Foo {
  foo @0 (a: Text, b: Int32) -> (c: Text);
}
```

then we can implement it like this:

```javascript
FooImpl.prototype.foo = function(a, b) {
  return {c : "the params are: " + a + ", " + b };
};
```

and we can call it from javascript like this:

```javascript
myFoo("hello", 42);
```


If instead the parameters to the method are defined in a separate struct, like this:

```capnp
interface Bar {
  bar @0 BarParams -> (c: Text);
}
struct BarParams {
  a @0 :Text;
  b @1 :Int32;
}
```

then when we implement the interface, the params are not automatically unpacked for us:

```javascript
BarImpl.prototype.bar = function(params) {
  return {c : "the params are: " + params.a + ", " + params.b };
};
```

However, when we call the interface, the arguments are still automatically packed into a struct:

```javascript
myBar("hello", 42);
```

I think this is confusing and needlessly complicated.

## What this pull request changes

This pull request eliminates all automatic packing and unpacking of parameters. So the implementation of `Foo` above would change to look exactly like the implementation of `Bar`, and calling an interface would always look like:

```javascript
myBar({a: "hello", b: 42});
```

The main reasons for this change are simplicity and consistency. It's clear that in the general case we can't always automatically pack and unpack parameters (e.g. how would we handle unions?), so let's just do the simplest thing possible and never automatically pack or unpack them.

I think would make node-capnp significantly easier to learn and would also make it more consistent with [pycapnp](http://jparyani.github.io/pycapnp/quickstart.html#rpc).  (@jparyani, please correct me if I'm wrong about that.)

I've staged the pull request into two commits. The first has the server-side changes, the second has the client-side changes.